### PR TITLE
Restore python3.6 compatability

### DIFF
--- a/generator/scripts/makecrates.py
+++ b/generator/scripts/makecrates.py
@@ -12,14 +12,20 @@ based on available YAML files for each HT32 family.
 Usage: python3 scripts/makecrates.py devices/
 """
 import argparse
-from importlib import resources
 from pathlib import Path
+from sys import version_info
 from typing import Dict, List
 
 from loguru import logger
 
 from generator import resource
 from .shared import read_device_table
+
+if version_info.minor <= 6:
+    # py <=3.6 doesn't include importlib_resources as standard library, use a backport.
+    import importlib_resources as resources
+else:
+    from importlib import resources
 
 VERSION = "0.1.0"
 SVD2RUST_VERSION = "0.17.0"
@@ -88,16 +94,16 @@ def make_mods(devices):
 
 def make_device_clauses(devices):
     return (
-        " else ".join(
-            """\
-            if env::var_os("CARGO_FEATURE_{}").is_some() {{
-                "src/{}/device.x"
-            }}""".strip().format(
-                d.upper(), d
+            " else ".join(
+                """\
+                if env::var_os("CARGO_FEATURE_{}").is_some() {{
+                    "src/{}/device.x"
+                }}""".strip().format(
+                    d.upper(), d
+                )
+                for d in sorted(devices)
             )
-            for d in sorted(devices)
-        )
-        + ' else { panic!("No device features selected"); }'
+            + ' else { panic!("No device features selected"); }'
     )
 
 

--- a/generator/scripts/shared.py
+++ b/generator/scripts/shared.py
@@ -5,11 +5,17 @@ Copyright 2020 Henrik Böving
 Shared script functions
 
 """
-from importlib import resources
+from sys import version_info
 
 import yaml
 
 from generator import resource
+
+if version_info.minor <= 6:
+    # py <=3.6 doesn't include importlib_resources as standard library, use a backport.
+    import importlib_resources as resources
+else:
+    from importlib import resources
 
 
 def read_device_table():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 svdtools~=0.1.0
-
+importlib_resources ; python_version < '3.7'
 loguru~=0.5.0
 PyYAML~=5.3.1


### PR DESCRIPTION
Resolves the python3.6 incompatibility caused by #1 

Added dependencies:
[`importlib_resources`](https://pypi.org/project/importlib-resources/) backport, only installed on python < 3.7 
Backport will only be imported at runtime provided the minor release is less than 7. this does NOT check for python3 at all, but who uses python2 these days those monsters?