### PR TITLE
Update PAC generation

### DIFF
--- a/devices/common_patches/usb/endpoint_cluster.yaml
+++ b/devices/common_patches/usb/endpoint_cluster.yaml
@@ -1,0 +1,64 @@
+USB:
+  _modify:
+    USB_CSR:
+      description: USB control bits and USB data line status
+    USB_IER:
+      description: USB interrupt enable control
+    USB_ISR:
+      description: USB interrupt status
+    USB_FCR:
+      description: Lost Start-of-Frame number and the USB frame count
+    USB_DEVAR:
+      description: USB device address
+  _cluster:
+    "EP0":
+      description: USB control endpoint
+      USB_EP[0]CSR:
+        name: CSR
+        description: Endpoint control and status bits
+      USB_EP[0]IER:
+        name: IER
+        description: Endpoint interrupt enable control bits
+      USB_EP[0]ISR:
+        name: ISR
+        description: Endpoint interrupt status
+      USB_EP[0]TCR:
+        name: TCR
+        description: Endpoint data transfer byte count
+      USB_EP[0]CFGR:
+        name: CFGR
+        description: Endpoint configuration
+    "EP%sS":
+      description: USB single-buffered endpoints
+      USB_EP[123]CSR:
+        name: CSR
+        description: Endpoint control and status bits
+      USB_EP[123]IER:
+        name: IER
+        description: Endpoint interrupt enable control bits
+      USB_EP[123]ISR:
+        name: ISR
+        description: Endpoint interrupt status
+      USB_EP[123]TCR:
+        name: TCR
+        description: Endpoint data transfer byte count
+      USB_EP[123]CFGR:
+        name: CFGR
+        description: Endpoint configuration
+    "EP%sD":
+      description: USB double-buffered endpoints
+      USB_EP[4567]CSR:
+        name: CSR
+        description: Endpoint control and status bits
+      USB_EP[4567]IER:
+        name: IER
+        description: Endpoint interrupt enable control bits
+      USB_EP[4567]ISR:
+        name: ISR
+        description: Endpoint interrupt status
+      USB_EP[4567]TCR:
+        name: TCR
+        description: Endpoint data transfer byte count
+      USB_EP[4567]CFGR:
+        name: CFGR
+        description: Endpoint configuration

--- a/devices/ht32f1653_54.yaml
+++ b/devices/ht32f1653_54.yaml
@@ -1,1 +1,4 @@
 _svd: ../svd/ht32f1653_54.svd
+
+_include:
+ - common_patches/usb/endpoint_cluster.yaml

--- a/devices/ht32f1655_56.yaml
+++ b/devices/ht32f1655_56.yaml
@@ -1,1 +1,4 @@
 _svd: ../svd/ht32f1655_56.svd
+
+_include:
+ - common_patches/usb/endpoint_cluster.yaml

--- a/devices/ht32f175x.yaml
+++ b/devices/ht32f175x.yaml
@@ -1,1 +1,4 @@
 _svd: ../svd/ht32f175x.svd
+
+_include:
+ - common_patches/usb/endpoint_cluster.yaml

--- a/generator/resource/cargo.toml.template
+++ b/generator/resource/cargo.toml.template
@@ -11,19 +11,16 @@ categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-bare-metal = "0.2.4"
-vcell = "0.1.0"
-cortex-m = ">=0.5.8,<0.7"
-
-[dependencies.cortex-m-rt]
-optional = true
-version = "0.6.10"
+critical-section = {{ version = "1.0", optional = true }}
+cortex-m = "0.7.6"
+cortex-m-rt = {{ version = ">=0.6.15,<0.8", optional = true }}
+vcell = "0.1.3"
 
 [package.metadata.docs.rs]
 features = {docs_features}
 targets = []
 
 [features]
-default = []
+default = ["critical-section", "rt"]
 rt = ["cortex-m-rt/device"]
 {features}

--- a/generator/resource/src_lib.rs.template
+++ b/generator/resource/src_lib.rs.template
@@ -13,6 +13,8 @@
 //! [{crate}](https://github.com/ht32-rs/ht32-rs/tree/master/{crate})
 //!
 
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![no_std]
 
 mod generic;

--- a/generator/scripts/makemodules.py
+++ b/generator/scripts/makemodules.py
@@ -29,20 +29,21 @@ def make_modules():
             module_dir = ROOT / crate / "src" / module
             module_dir.mkdir(parents=True, exist_ok=True)
             logger.debug("entering {}", module_dir.absolute())
-            svd_result = subprocess.check_call(
-                ["svd2rust", "-g", "-i", f"{output_patch.absolute()}"], cwd=module_dir
+            svd_result = subprocess.call(
+                ["svd2rust", "-m", "-g", "--strict", "--pascal_enum_values",
+                 "--max_cluster_size", "-i", f"{output_patch.absolute()}"],
+                cwd=module_dir
             )
-            logger.debug("check_call svd2rust := {}", svd_result)
+            logger.debug("subprocess call svd2rust := {}", svd_result)
             (module_dir / "build.rs").unlink()
             (module_dir / "generic.rs").replace(module_dir / ".." / "generic.rs")
-            (module_dir / "lib.rs").replace(module_dir / "mod.rs")
-            form_result = subprocess.check_call(["form", "-i", "mod.rs", "-o", "."], cwd=module_dir)
-            logger.debug("check_call form := {}", form_result)
+            form_result = subprocess.call(["form", "-i", "mod.rs", "-o", "."], cwd=module_dir)
+            logger.debug("subprocess call form := {}", form_result)
             (module_dir / "lib.rs").replace(module_dir / "mod.rs")
             rustfmt_args = ["rustfmt", f"--config-path={RUST_FMT.absolute()}"]
-            rustfmt_args.extend(module_dir.glob("*.rs"))
-            rustfmt_result = subprocess.check_call(rustfmt_args, cwd=module_dir)
-            logger.debug("check_call rustfmt := {}", rustfmt_result)
+            rustfmt_args.extend([str(i) for i in module_dir.glob("*.rs")])
+            rustfmt_result = subprocess.call(rustfmt_args, cwd=module_dir)
+            logger.debug("subprocess call rustfmt := {}", rustfmt_result)
             lines = (module_dir / "mod.rs").read_text().splitlines(keepends=True)
 
             # these are lines that annoy rustc

--- a/generator/scripts/patch.py
+++ b/generator/scripts/patch.py
@@ -11,7 +11,7 @@ Usage: python3 scripts/patch.py devices/
 import argparse
 from pathlib import Path
 
-import svdtools
+import subprocess
 from loguru import logger
 
 
@@ -19,7 +19,8 @@ def patch_files(device_path: Path):
     device_files = [f for f in device_path.iterdir() if f.is_file()]
     for path in device_files:
         logger.debug("patching {}...", path)
-        svdtools.patch.main(f"{path.absolute()}")
+        svdtools_result = subprocess.call(["svdtools", "patch", f"{path.absolute()}"])
+        logger.debug("subprocess call svdtools := {}", svdtools_result)
 
 
 if __name__ == "__main__":

--- a/svd/extract.sh
+++ b/svd/extract.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -ev
-wget http://mcu.holtek.com.tw/pack/Holtek.HT32_DFP.1.0.25.pack -O holtek_pack.zip
+wget https://mcu.holtek.com.tw/pack/Holtek.HT32_DFP.1.0.44.pack -O holtek_pack.zip
 unzip -LL holtek_pack.zip
 rm -r arm holtek.ht32_dfp.pdsc
 mv svd/* .


### PR DESCRIPTION
This PR:
- updates the link to the SVD pack
- updates the templates by looking at the current state of stm32-rs
- switches to the rust version of `svdtools` (since the code generated by the Python version had some issues)
- adds a patch file that clusters the USB endpoints that are identical

With these changes, the generated PACs are up to speed again with the latest developments in `cortex-m`, `svd2rust`, etc.
I will also create a separate PR to update the github workflow configuration.