### PR TITLE
Update github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,11 @@ jobs:
         with:
           command: install
           args: form --version 0.10.0
+      - name: Install svdtools
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: svdtools --version 0.3.0
       - name: Put cargo binary directory into path
         run: |
           echo "::add-path::~/cargo-bin"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: svd2rust --version 0.17.0
+          args: svd2rust --version 0.29.0
       - name: Install form
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: form --version 0.7.0
+          args: form --version 0.10.0
       - name: Put cargo binary directory into path
         run: |
           echo "::add-path::~/cargo-bin"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,6 +38,11 @@ jobs:
         with:
           command: install
           args: form --version 0.10.0
+      - name: Install svdtools
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: svdtools --version 0.3.0
       - name: Put cargo binary directory into path
         run: |
           echo "::add-path::~/cargo-bin"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,12 +32,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: svd2rust --version 0.17.0
+          args: svd2rust --version 0.29.0
       - name: Install form
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: form --version 0.7.0
+          args: form --version 0.10.0
       - name: Put cargo binary directory into path
         run: |
           echo "::add-path::~/cargo-bin"


### PR DESCRIPTION
This PR updates `svd2rust` and `form` to use their latest versions.
It also adds `svdtools`, which is necessary for the changes in #3 